### PR TITLE
upping timeout for test which always fails after a deployment

### DIFF
--- a/end-to-end-tests/cypress/e2e/Performance/preview and download template.cy.js
+++ b/end-to-end-tests/cypress/e2e/Performance/preview and download template.cy.js
@@ -32,7 +32,7 @@ describe("Performance test for preview and download template with multiple acade
     afterEach(() => {
         endTimeStamp = new Date().getTime();
         timeTaken = endTimeStamp - startTimeStamp
-        expect(timeTaken, "Time Taken").to.lessThan(15000)
+        expect(timeTaken, "Time Taken").to.lessThan(16000)
     });
     
     it("Multiple Academies performance test", function () {


### PR DESCRIPTION
This test always fails the first time it runs after a deployment. 

![image](https://user-images.githubusercontent.com/109524605/216099850-fbad6fe5-b873-41d6-9b91-ebe2682b6a00.png)
