### PR TITLE
Fix performance test

### DIFF
--- a/end-to-end-tests/cypress/e2e/Performance/preview and download template.cy.js
+++ b/end-to-end-tests/cypress/e2e/Performance/preview and download template.cy.js
@@ -28,12 +28,6 @@ describe("Performance test for preview and download template with multiple acade
         startTimeStamp = new Date().getTime();
         cy.login();
     });
-
-    afterEach(() => {
-        endTimeStamp = new Date().getTime();
-        timeTaken = endTimeStamp - startTimeStamp
-        expect(timeTaken, "Time Taken").to.lessThan(16000)
-    });
     
     it("Multiple Academies performance test", function () {
         //Log the test run environment
@@ -95,6 +89,7 @@ describe("Performance test for preview and download template with multiple acade
         cy.log("endTimeStamp = " + endTimeStamp)
         timeTaken = endTimeStamp - startTimeStamp
         cy.log("Time take = " + timeTaken);
+        expect(timeTaken, "Time Taken").to.lessThan(16000);
     });
 
     after(function () {


### PR DESCRIPTION
Atm this performance was failing intermittently. Looking into the code it seems we were repeating some of the time logging. Also in the test case we don't need afterEach function as there is only one  test and the assertion we were checking in this function could also be done with in the test case
It has decreased the timeTaken value
<img width="714" alt="time performance fix" src="https://user-images.githubusercontent.com/116153732/216308594-750118e2-da8b-4830-86fb-8d2352fa9cf7.png">
<img width="655" alt="staging performance fix" src="https://user-images.githubusercontent.com/116153732/216308644-aa145920-f6b0-44d9-a663-68ba0ceeebdd.png">
