### PR TITLE
Added NS record option for delegating subdomains

### DIFF
--- a/terraform.gpaas-azure-migration/README.md
+++ b/terraform.gpaas-azure-migration/README.md
@@ -158,6 +158,7 @@ No resources.
 | <a name="input_container_health_probe_path"></a> [container\_health\_probe\_path](#input\_container\_health\_probe\_path) | Specifies the path that is used to determine the liveness of the Container | `string` | n/a | yes |
 | <a name="input_container_max_replicas"></a> [container\_max\_replicas](#input\_container\_max\_replicas) | Container max replicas | `number` | n/a | yes |
 | <a name="input_container_secret_environment_variables"></a> [container\_secret\_environment\_variables](#input\_container\_secret\_environment\_variables) | Container secret environment variables | `map(string)` | n/a | yes |
+| <a name="input_dns_ns_records"></a> [dns\_ns\_records](#input\_dns\_ns\_records) | DNS NS records to add to the DNS Zone | <pre>map(<br>    object({<br>      ttl : optional(number, 300),<br>      records : list(string)<br>    })<br>  )</pre> | n/a | yes |
 | <a name="input_dns_zone_domain_name"></a> [dns\_zone\_domain\_name](#input\_dns\_zone\_domain\_name) | DNS zone domain name. If created, records will automatically be created to point to the CDN. | `string` | n/a | yes |
 | <a name="input_enable_cdn_frontdoor"></a> [enable\_cdn\_frontdoor](#input\_enable\_cdn\_frontdoor) | Set to true to create a CDN | `bool` | n/a | yes |
 | <a name="input_enable_container_registry"></a> [enable\_container\_registry](#input\_enable\_container\_registry) | Set to true to create a container registry | `bool` | n/a | yes |

--- a/terraform.gpaas-azure-migration/container-apps-hosting.tf
+++ b/terraform.gpaas-azure-migration/container-apps-hosting.tf
@@ -14,6 +14,7 @@ module "azure_container_apps_hosting" {
 
   enable_dns_zone      = local.enable_dns_zone
   dns_zone_domain_name = local.dns_zone_domain_name
+  dns_ns_records       = local.dns_ns_records
 
   image_name                             = local.image_name
   container_command                      = local.container_command

--- a/terraform.gpaas-azure-migration/locals.tf
+++ b/terraform.gpaas-azure-migration/locals.tf
@@ -12,6 +12,7 @@ locals {
   enable_event_hub                             = var.enable_event_hub
   enable_dns_zone                              = var.enable_dns_zone
   dns_zone_domain_name                         = var.dns_zone_domain_name
+  dns_ns_records                               = var.dns_ns_records
   enable_cdn_frontdoor                         = var.enable_cdn_frontdoor
   cdn_frontdoor_enable_rate_limiting           = var.cdn_frontdoor_enable_rate_limiting
   cdn_frontdoor_rate_limiting_threshold        = var.cdn_frontdoor_rate_limiting_threshold

--- a/terraform.gpaas-azure-migration/variables.tf
+++ b/terraform.gpaas-azure-migration/variables.tf
@@ -145,6 +145,16 @@ variable "dns_zone_domain_name" {
   type        = string
 }
 
+variable "dns_ns_records" {
+  description = "DNS NS records to add to the DNS Zone"
+  type = map(
+    object({
+      ttl : optional(number, 300),
+      records : list(string)
+    })
+  )
+}
+
 variable "cdn_frontdoor_custom_domains" {
   description = "Azure CDN Front Door custom domains. If they are within the DNS zone (optionally created), the Validation TXT records and ALIAS/CNAME records will be created"
   type        = list(string)


### PR DESCRIPTION
Adding NS records to your primary DNS Zone allows you to delegate records for subdomains into their own individual Zones instead of managing all records in your primary Zone.