### PR TITLE
Removing expose line which GPaaS doesn't like.

### DIFF
--- a/Dfe.PrepareTransfers.Redirector/Dockerfile
+++ b/Dfe.PrepareTransfers.Redirector/Dockerfile
@@ -27,5 +27,4 @@ ARG ASPNET_IMAGE_TAG
 FROM "mcr.microsoft.com/dotnet/aspnet:${ASPNET_IMAGE_TAG}" AS final
 COPY --from=dotnetBuild /app /app
 WORKDIR /app
-EXPOSE 80/tcp
 ENTRYPOINT ["dotnet", "Dfe.PrepareTransfers.Redirector.dll"]


### PR DESCRIPTION
The line is not required because the base image already exposes a port. GPaaS doesn't work with this line in (not sure why)