### PR TITLE
Update security test workflow to upload report to blob storage

### DIFF
--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -33,6 +33,12 @@ jobs:
           CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
           echo "checked_out_sha=${CHECKED_OUT_SHA}" >> $GITHUB_ENV
 
+      - name: Azure login with SPN
+        if: '!cancelled()'
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.OWASP_AZ_CREDENTIALS }}
+
       - name: Push report to blob storage
         if: '!cancelled()'
         uses: azure/CLI@v1
@@ -40,4 +46,10 @@ jobs:
         with:
           azcliversion: 2.49.0
           inlineScript: |
-            az storage azcopy blob upload -c ${{ secrets.OWASP_STORAGE_CONTAINER_NAME }} --account-name ${{ secrets.OWASP_STORAGE_ACCOUNT_NAME }} -s "end-to-end-tests/reports/ZAP-Report.html" -d "Dfe.PrepareTransfers/${{ env.checked_out_sha }}/ZAP-Report.html" --sas-token "${{ secrets.OWASP_BLOB_SAS_TOKEN }}"
+            az storage blob upload \
+              --container-name ${{ secrets.OWASP_STORAGE_CONTAINER_NAME }} \
+              --account-name ${{ secrets.OWASP_STORAGE_ACCOUNT_NAME }} \
+              --file "end-to-end-tests/reports/ZAP-Report.html" \
+              --name "Dfe.PrepareTransfers/${{ env.checked_out_sha }}/ZAP-Report.html" \
+              --auth-mode login \
+              --overwrite

--- a/.github/workflows/security-tests.yml
+++ b/.github/workflows/security-tests.yml
@@ -2,7 +2,7 @@ name: Security scanner tests
 
 on:
   workflow_run:
-    workflows: ["Test, build, and deploy"]
+    workflows: ["Deploy to environment"]
     types:
       - completed
 
@@ -15,20 +15,29 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Prepare environment
-        run: |
-          echo "URL=${{ secrets.ENDPOINT }}" >> $GITHUB_ENV
-          echo "API_KEY=${{ secrets.AUTH_HEADER_CYPRESS }}" >> $GITHUB_ENV
-          echo "HTTP_PROXY=http://zap:8080" >> $GITHUB_ENV
-          echo "NO_PROXY=*.google-analytics.com,*.googletagmanager.com,*.microsoftonline.com" >> $GITHUB_ENV
-          echo "ZAP_API_KEY=${{ secrets.ZAP_API_KEY }}" >> $GITHUB_ENV
-
       - name: Run tests with scanner
+        env:
+          AUTH_HEADER: ${{ secrets.AUTH_HEADER_CYPRESS }}
+          DB_CONN: ${{ secrets.DB_CONNECTION_STRING }}
+          HTTP_PROXY: http://zap:8080
+          KEY: ${{ secrets.CYPRESS_KEY }}
+          NO_PROXY: "*.google-analytics.com,*.googletagmanager.com,*.microsoftonline.com"
+          URL: ${{ secrets.AZURE_ENDPOINT }}
+          ZAP_API_KEY: ${{ secrets.ZAP_API_KEY }}
         run: |
           docker-compose -f end-to-end-tests/docker-compose.yml up --exit-code-from cypress
 
-      # TODO report metrics through another system
-      # - uses: actions/upload-artifact@v1
-      #   with:
-      #     name: report
-      #     path: ./end-to-end-tests/ZAP-Report.html
+      - name: Get git sha
+        if: '!cancelled()'
+        run: |
+          CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
+          echo "checked_out_sha=${CHECKED_OUT_SHA}" >> $GITHUB_ENV
+
+      - name: Push report to blob storage
+        if: '!cancelled()'
+        uses: azure/CLI@v1
+        id: azure
+        with:
+          azcliversion: 2.49.0
+          inlineScript: |
+            az storage azcopy blob upload -c ${{ secrets.OWASP_STORAGE_CONTAINER_NAME }} --account-name ${{ secrets.OWASP_STORAGE_ACCOUNT_NAME }} -s "end-to-end-tests/reports/ZAP-Report.html" -d "Dfe.PrepareTransfers/${{ env.checked_out_sha }}/ZAP-Report.html" --sas-token "${{ secrets.OWASP_BLOB_SAS_TOKEN }}"

--- a/end-to-end-tests/docker-compose.yml
+++ b/end-to-end-tests/docker-compose.yml
@@ -9,12 +9,13 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
-    command: -- --env url="${URL}",authorizationHeader="${API_KEY}",zapReport=true,zapApiKey=${ZAP_API_KEY},zapUrl="${HTTP_PROXY}"
+    command: -- --key ${KEY} --env url="${URL}",authorizationHeader="${AUTH_HEADER}",zapReport=true,zapApiKey=${ZAP_API_KEY},zapUrl="${HTTP_PROXY}"
     depends_on:
       zap:
         condition: service_healthy
     environment:
       - HTTP_PROXY=${HTTP_PROXY}
       - NO_PROXY="${NO_PROXY}"
+      - db=${DB_CONN}
     volumes:
-      - ./:/reports
+      - ./reports:/reports:rw


### PR DESCRIPTION
Fixes configuration in the security tests workflow to allow the report to be uploaded to Azure Blob Storage for later viewing. Reports will always upload, regardless of test failures, as long as the action is not cancelled.

Files will be uploaded to a [container](https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/1d692707-6019-4f8c-b337-ec8cad61f998/resourceGroups/s184d01-rsd-owasp-reports/providers/Microsoft.Storage/storageAccounts/s184d01rsdowaspreports/storagebrowser) on Azure under the directory `<project>/<git-hash>/ZAP-Report.html`.

> **Note**
> To read them you will need read access to Azure CIP.

Makes use of a Service Principal account to authenticate to Azure

**Notes**
The following need to be completed before this PR can be merged:

- [x] Blob storage needs to be configured in Azure for reports to be uploaded to
- [x] ZAP_API_KEY secret will need adding to repository secrets (message me separately for info)