### PR TITLE
Adds Cypress linting workflow for PRs with Cypress changes

### DIFF
--- a/.github/workflows/continuous-integration-javascript.yml
+++ b/.github/workflows/continuous-integration-javascript.yml
@@ -1,0 +1,21 @@
+name: Cypress test linting
+
+on:
+  pull_request:
+    paths:
+      - end-to-end-tests
+    types: [opened, synchronize]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    defaults:
+      working-directory: end-to-end-tests
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: lint cypress tests
+        run: |
+          npm ci
+          npm run lint        

--- a/end-to-end-tests/cypress/.eslintrc.json
+++ b/end-to-end-tests/cypress/.eslintrc.json
@@ -3,7 +3,7 @@
       "cypress"
     ],
     "rules": {
-      "cypress/no-assigning-return-values": "warn",
+      "cypress/no-assigning-return-values": "error",
       "cypress/no-unnecessary-waiting": "error",
       "cypress/assertion-before-screenshot": "error",
       "cypress/no-force": "error",

--- a/end-to-end-tests/cypress/e2e/cookie-policy/cookies-policy.cy.js
+++ b/end-to-end-tests/cypress/e2e/cookie-policy/cookies-policy.cy.js
@@ -23,9 +23,9 @@ Cypress._.each(['ipad-mini'], (viewport) => {
 			})
 
 			it('TC02: should consent to cookies from cookie header button', () => {
-				let consentCookie = cy.getCookie('.ManageAnAcademyTransfer.Consent')
-				consentCookie.should('exist')
-				consentCookie.should('have.property', 'value', 'True')
+				cy.getCookie('.ManageAnAcademyTransfer.Consent')
+				.should('exist')
+				.should('have.property', 'value', 'True')
 			});
 
 			it('TC03: should hide the cookie banner when consent has been given', () => {


### PR DESCRIPTION
Adds a workflow for Cypress linting when changes are made to it in a PR (shouldn't run if no changes are present in the `end-to-end-tests` directory)

Will fail the job if any of the configured rules return an error.