### PR TITLE
Transfer date fixes

### DIFF
--- a/Dfe.PrepareTransfers.Data.TRAMS.Tests/Mappers/Request/InternalProjectToUpdateMapperTests.cs
+++ b/Dfe.PrepareTransfers.Data.TRAMS.Tests/Mappers/Request/InternalProjectToUpdateMapperTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Dfe.PrepareTransfers.Data.Models;
 using Dfe.PrepareTransfers.Data.Models.Projects;
@@ -132,8 +133,8 @@ namespace Dfe.PrepareTransfers.Data.TRAMS.Tests.Mappers.Request
             {
                 Dates = new TransferDates
                 {
-                    Htb = "Date1",
-                    Target = "Date2",
+                    Htb = "10/10/2023",
+                    Target = "10/10/2024",
                     HasHtbDate = null,
                     HasTargetDateForTransfer = null,
                 },
@@ -142,8 +143,8 @@ namespace Dfe.PrepareTransfers.Data.TRAMS.Tests.Mappers.Request
             var result = subject.Map(toMap);
             Assert.Null(result.Dates.HasHtbDate);
             Assert.Null(result.Dates.HasTargetDateForTransfer);
-            Assert.Equal(result.Dates.HtbDate, toMap.Dates.Htb);
-            Assert.Equal(result.Dates.TargetDateForTransfer, toMap.Dates.Target);
+            Assert.Equal(DateTime.Parse(toMap.Dates.Htb).ToString("u"), result.Dates.HtbDate);
+            Assert.Equal(DateTime.Parse(toMap.Dates.Target).ToString("u"), result.Dates.TargetDateForTransfer);
         }
 
         private static void AssertGeneralInformationIsCorrect(Project toMap, TramsProjectUpdate result)
@@ -169,8 +170,8 @@ namespace Dfe.PrepareTransfers.Data.TRAMS.Tests.Mappers.Request
 
         private static void AssertDatesAreCorrect(Project toMap, TramsProjectUpdate result)
         {
-            Assert.Equal(toMap.Dates.Htb, result.Dates.HtbDate);
-            Assert.Equal(toMap.Dates.Target, result.Dates.TargetDateForTransfer);
+            Assert.Equal(DateTime.Parse(toMap.Dates.Htb).ToString("u"), result.Dates.HtbDate);
+            Assert.Equal(DateTime.Parse(toMap.Dates.Target).ToString("u"), result.Dates.TargetDateForTransfer);
             Assert.True(result.Dates.HasHtbDate);
             Assert.True(result.Dates.HasTargetDateForTransfer);
         }

--- a/Dfe.PrepareTransfers.Data.TRAMS/Mappers/Request/InternalProjectToUpdateMapper.cs
+++ b/Dfe.PrepareTransfers.Data.TRAMS/Mappers/Request/InternalProjectToUpdateMapper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Dfe.PrepareTransfers.Data.Models;
@@ -74,9 +75,9 @@ namespace Dfe.PrepareTransfers.Data.TRAMS.Mappers.Request
         {
             return new AcademyTransferProjectDates
             {
-                HtbDate = input.Dates.HasHtbDate != false ? input.Dates.Htb : null,
+                HtbDate = input.Dates.HasHtbDate != false && input.Dates.Htb != null ? DateTime.Parse(input.Dates.Htb).ToString("u") : null,
                 HasHtbDate = input.Dates.HasHtbDate,
-                TargetDateForTransfer = input.Dates.HasTargetDateForTransfer != false ? input.Dates.Target : null,
+                TargetDateForTransfer = input.Dates.HasTargetDateForTransfer != false && input.Dates.Target != null ? DateTime.Parse(input.Dates.Target).ToString("u") : null,
                 HasTargetDateForTransfer = input.Dates.HasTargetDateForTransfer
             };
         }

--- a/Dfe.PrepareTransfers.Web.Tests/PagesTests/Projects/TransferDates/AdvisoryBoardTests.cs
+++ b/Dfe.PrepareTransfers.Web.Tests/PagesTests/Projects/TransferDates/AdvisoryBoardTests.cs
@@ -94,7 +94,7 @@ namespace Dfe.PrepareTransfers.Web.Tests.PagesTests.Projects.TransferDates
 
                 ProjectRepository.Verify(r =>
                         r.UpdateDates(It.Is<Data.Models.Project>(project =>
-                            project.Dates.Htb == _subject.AdvisoryBoardViewModel.AdvisoryBoardDate.DateInputAsUniversalDateTimeString()
+                            project.Dates.Htb == _subject.AdvisoryBoardViewModel.AdvisoryBoardDate.DateInputAsString()
                             && project.Dates.HasHtbDate ==
                             !_subject.AdvisoryBoardViewModel.AdvisoryBoardDate.UnknownDate)),
                     Times.Once);

--- a/Dfe.PrepareTransfers.Web.Tests/PagesTests/Projects/TransferDates/TargetTests.cs
+++ b/Dfe.PrepareTransfers.Web.Tests/PagesTests/Projects/TransferDates/TargetTests.cs
@@ -125,7 +125,7 @@ namespace Dfe.PrepareTransfers.Web.Tests.PagesTests.Projects.TransferDates
 
                 ProjectRepository.Verify(r =>
                         r.UpdateDates(It.Is<Data.Models.Project>(project =>
-                            project.Dates.Target == _subject.TargetDateViewModel.TargetDate.DateInputAsUniversalDateTimeString()
+                            project.Dates.Target == _subject.TargetDateViewModel.TargetDate.DateInputAsString()
                             && project.Dates.HasTargetDateForTransfer ==
                             !_subject.TargetDateViewModel.TargetDate.UnknownDate)),
                     Times.Once);

--- a/Dfe.PrepareTransfers.Web/Pages/Projects/TransferDates/AdvisoryBoard.cshtml.cs
+++ b/Dfe.PrepareTransfers.Web/Pages/Projects/TransferDates/AdvisoryBoard.cshtml.cs
@@ -67,14 +67,7 @@ namespace Dfe.PrepareTransfers.Web.Pages.Projects.TransferDates
                 return Page();
             }
 
-            if (AdvisoryBoardViewModel.AdvisoryBoardDate.UnknownDate)
-            {
-                projectResult.Dates.Htb = null;
-            }
-            else
-            {
-                projectResult.Dates.Htb = AdvisoryBoardViewModel.AdvisoryBoardDate.DateInputAsUniversalDateTimeString();
-            }
+            projectResult.Dates.Htb = AdvisoryBoardViewModel.AdvisoryBoardDate.DateInputAsString();
             projectResult.Dates.HasHtbDate = !AdvisoryBoardViewModel.AdvisoryBoardDate.UnknownDate;
 
             await _projectsRepository.UpdateDates(projectResult);

--- a/Dfe.PrepareTransfers.Web/Pages/Projects/TransferDates/Target.cshtml.cs
+++ b/Dfe.PrepareTransfers.Web/Pages/Projects/TransferDates/Target.cshtml.cs
@@ -71,14 +71,7 @@ namespace Dfe.PrepareTransfers.Web.Pages.Projects.TransferDates
                 return Page();
             }
 
-            if (TargetDateViewModel.TargetDate.UnknownDate)
-            {
-                projectResult.Dates.Target = null;
-            }
-            else
-            {
-                projectResult.Dates.Target = TargetDateViewModel.TargetDate.DateInputAsUniversalDateTimeString();
-            }
+            projectResult.Dates.Target = TargetDateViewModel.TargetDate.DateInputAsString();
 
             projectResult.Dates.HasTargetDateForTransfer = !TargetDateViewModel.TargetDate.UnknownDate;
 


### PR DESCRIPTION
Moved the fix for transfer dates to the request mapping layer, outgoing dates are now universal datetime to avoid deserialization issues. Probably need to standardize these in the API in the JSON settings going forward. 