### PR TITLE
Add Cypress User-Agent header to config

### DIFF
--- a/end-to-end-tests/cypress.config.js
+++ b/end-to-end-tests/cypress.config.js
@@ -19,6 +19,7 @@ module.exports = defineConfig({
 
   modifyObstructiveCode: true,
   chromeWebSecurity: false,
+  userAgent: 'PrepareTransfers/1.0 Cypress',
 
   e2e: {
     setupNodeEvents(on, config) {


### PR DESCRIPTION
Adds a User-Agent header for Cypress tests to mitigate issues with Azure thinking the traffic is from bots