### PR TITLE
move filter into separate model

### DIFF
--- a/Dfe.PrepareTransfers.Web.Tests/ModelTests/ProjectListTests/ProjectListFiltersTests.cs
+++ b/Dfe.PrepareTransfers.Web.Tests/ModelTests/ProjectListTests/ProjectListFiltersTests.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using Dfe.PrepareTransfers.Web.Models.ProjectList;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Dfe.PrepareTransfers.Web.Tests.ModelTests.ProjectListTests.ProjectFilterListTests
+{
+    public class ProjectListFiltersTests
+    {
+        [Fact]
+        public void PopulateFrom_ClearsFilters_WhenClearQueryParameterExists()
+        {
+            // Arrange
+            var filters = new ProjectListFilters();
+            var store = new Dictionary<string, object>
+            {
+                { ProjectListFilters.FilterTitle, new string[] { "Bishop" } }
+            };
+
+            filters.PersistUsing(store);
+
+            var queryParameters = new List<KeyValuePair<string, StringValues>>
+            {
+                new("clear", new StringValues(new[] { "true" }))
+            };
+
+            // Act
+            filters.PopulateFrom(queryParameters);
+
+            // Assert
+            Assert.False(filters.IsFiltered);
+        }
+
+        [Fact]
+        public void PersistUsing_SetsTitle_WhenStoreContainsTitle()
+        {
+            // Arrange
+            var filters = new ProjectListFilters();
+            var store = new Dictionary<string, object>
+            {
+                { ProjectListFilters.FilterTitle, new string[] { "Bishop" } }
+            };
+
+            // Act
+            filters.PersistUsing(store);
+
+            // Assert
+            Assert.Equal("Bishop", filters.Title);
+        }
+
+        [Fact]
+        public void ClearFiltersFrom_RemovesAllFiltersFromStore()
+        {
+            // Arrange
+            var store = new Dictionary<string, object>
+            {
+                { ProjectListFilters.FilterTitle, new string[] { "Bishop" } }
+            };
+
+            // Act
+            ProjectListFilters.ClearFiltersFrom(store);
+
+            // Assert
+            Assert.Empty(store);
+        }
+    }
+}

--- a/Dfe.PrepareTransfers.Web.Tests/PagesTests/Home/IndexTests.cs
+++ b/Dfe.PrepareTransfers.Web.Tests/PagesTests/Home/IndexTests.cs
@@ -2,7 +2,10 @@ using System.Collections.Generic;
 using Dfe.PrepareTransfers.Data;
 using Dfe.PrepareTransfers.Data.Models;
 using Dfe.PrepareTransfers.Web.Pages.Home;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -14,10 +17,24 @@ namespace Dfe.PrepareTransfers.Web.Tests.PagesTests.Home
         private readonly Mock<ILogger<Index>> _logger = new Mock<ILogger<Index>>();
         private readonly Index _subject;
         private readonly Mock<IUrlHelper> _urlHelper = new Mock<IUrlHelper>();
-        
+
         public IndexTests()
         {
-            _subject = new Index(ProjectRepository.Object, _logger.Object);
+            var tempData = new Mock<ITempDataDictionary>();
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Query = new QueryCollection();
+
+            var pageContext = new PageContext
+            {
+                HttpContext = httpContext
+            };
+
+            _subject = new Index(ProjectRepository.Object, _logger.Object)
+            {
+                PageContext = pageContext,
+                TempData = tempData.Object
+            };
+
             var foundProjects = new List<ProjectSearchResult>
             {
                 new ProjectSearchResult {Urn = "1"},

--- a/Dfe.PrepareTransfers.Web.Tests/UtilsTests/TypeSpaceExtensionsTests.cs
+++ b/Dfe.PrepareTransfers.Web.Tests/UtilsTests/TypeSpaceExtensionsTests.cs
@@ -1,0 +1,24 @@
+﻿using Xunit;
+using Dfe.PrepareTransfers.Web.Utils;
+
+namespace Dfe.PrepareTransfers.Web.Tests.UtilsTests
+{
+    public class TypespaceExtensionsTests
+    {
+        [Theory]
+        [InlineData("Hello World", "hello-world")]
+        [InlineData("This is a test", "this-is-a-test")]
+        [InlineData("123-456", "123-456")]
+        [InlineData("", "")]
+        [InlineData("Hello World!", "hello-world-")]
+        public void Stub_ReturnsExpectedResult(string input, string expected)
+        {
+            // Arrange
+            // Act
+            var result = input.Stub();
+
+            // Assert
+            Assert.Equal(expected, result.Value);
+        }
+    }
+}

--- a/Dfe.PrepareTransfers.Web/Models/ProjectList/ProjectListFilters.cs
+++ b/Dfe.PrepareTransfers.Web/Models/ProjectList/ProjectListFilters.cs
@@ -17,7 +17,7 @@ public class ProjectListFilters
     [BindProperty]
     public string? Title { get; set; }
 
-    public bool IsFiltered => string.IsNullOrWhiteSpace(Title) is false;
+    public bool IsFiltered => !string.IsNullOrWhiteSpace(Title);
 
     public ProjectListFilters PersistUsing(IDictionary<string, object?> store)
     {
@@ -54,7 +54,7 @@ public class ProjectListFilters
 
     private string[] Get(string key, bool persist = false)
     {
-        if (_store.ContainsKey(key) is false) return Array.Empty<string>();
+        if (!_store.ContainsKey(key)) return Array.Empty<string>();
 
         string[]? value = (string[]?)_store[key];
         if (persist) Cache(key, value);

--- a/Dfe.PrepareTransfers.Web/Models/ProjectList/ProjectListFilters.cs
+++ b/Dfe.PrepareTransfers.Web/Models/ProjectList/ProjectListFilters.cs
@@ -1,0 +1,91 @@
+﻿#nullable enable
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Dfe.PrepareTransfers.Web.Models.ProjectList;
+
+public class ProjectListFilters
+{
+    public const string FilterTitle = nameof(FilterTitle);
+
+    private IDictionary<string, object?> _store = null!;
+
+    [BindProperty]
+    public string? Title { get; set; }
+
+    public bool IsFiltered => string.IsNullOrWhiteSpace(Title) is false;
+
+    public ProjectListFilters PersistUsing(IDictionary<string, object?> store)
+    {
+        _store = store;
+
+        Title = Get(FilterTitle).FirstOrDefault()?.Trim();
+
+        return this;
+    }
+
+    public void PopulateFrom(IEnumerable<KeyValuePair<string, StringValues>> requestQuery)
+    {
+        Dictionary<string, StringValues>? query = new(requestQuery, StringComparer.OrdinalIgnoreCase);
+
+        if (query.ContainsKey("clear"))
+        {
+            ClearFilters();
+
+            Title = default;
+
+            return;
+        }
+
+        Title = query.ContainsKey(nameof(Title))
+            ? Cache(FilterTitle, GetFromQuery(nameof(Title))).FirstOrDefault()?.Trim()
+            : Get(FilterTitle, true).FirstOrDefault()?.Trim();
+
+
+        string[] GetFromQuery(string key)
+        {
+            return query.ContainsKey(key) ? query[key]! : Array.Empty<string>();
+        }
+    }
+
+    private string[] Get(string key, bool persist = false)
+    {
+        if (_store.ContainsKey(key) is false) return Array.Empty<string>();
+
+        string[]? value = (string[]?)_store[key];
+        if (persist) Cache(key, value);
+
+        return value ?? Array.Empty<string>();
+    }
+
+    private string[] Cache(string key, string[]? value)
+    {
+        if (value is null || value.Length == 0)
+            _store.Remove(key);
+        else
+            _store[key] = value;
+
+        return value ?? Array.Empty<string>();
+    }
+
+    private void ClearFilters()
+    {
+        Cache(FilterTitle, default);
+    }
+
+    /// <summary>
+    ///    Removes all project list filters from the store
+    /// </summary>
+    /// <param name="store">the store used to cache filters between pages</param>
+    /// <remarks>
+    ///    Note that, when using TempData, this won't take effect until after the next request context that returns a 2xx response!
+    /// </remarks>
+    public static void ClearFiltersFrom(IDictionary<string, object?> store)
+    {
+        new ProjectListFilters().PersistUsing(store).ClearFilters();
+    }
+}

--- a/Dfe.PrepareTransfers.Web/Pages/Home/Index.cshtml
+++ b/Dfe.PrepareTransfers.Web/Pages/Home/Index.cshtml
@@ -20,7 +20,7 @@
     {   
 }
 
-    @if (Model.IsFiltered)
+    @if (Model.Filters.IsFiltered)
 {
     <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
         <div class="govuk-notification-banner__header">
@@ -59,45 +59,7 @@
             @Model.TotalProjectCount projects found
         </h2>
 
-        <details class="govuk-details prepare-project-listing__filters-container" data-module="govuk-details" @(Model.IsFiltered ? "open" : null)>
-            <summary class="govuk-details__summary prepare-project-listing__fitlers-details-summary">
-                <span class="govuk-details__summary-text govuk-button govuk-button--secondary prepare-project-listing__button--main" data-cy="select-projectlist-filter-expand">
-                    Filter projects
-                </span>
-            </summary>
-            <div class="govuk-details__text prepare-project-listing__filters-details" data-id="filter-container">
-                <form method="get" class="form">
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-one-quarter">
-                            <div class="govuk-form-group">
-                                <h1 class="govuk-label-wrapper">
-                                    <label class="govuk-label govuk-label--s" for="filter-project-title">
-                                        Project title
-                                    </label>
-                                </h1>
-                                <div id="filter-project-title-hint" class="govuk-hint">
-                                    For example, The Rutland Learning Trust
-                                </div>
-
-                                <input asp-for="TitleFilter" class="govuk-input" type="text" aria-describedby="filter-project-title-hint">
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-full">
-                            <div class="govuk-button-group">
-                                <button class="govuk-button govuk-button--secondary prepare-project-listing__button--apply" data-cy="select-projectlist-filter-apply" data-module="govuk-button ">
-                                    Apply filters
-                                </button>
-
-                                <a class="govuk-link" href="/home">Clear filters</a>
-                            </div>
-                        </div>
-                    </div>
-                </form>
-            </div>
-        </details>
+        <partial name="Shared/_ProjectListFilters" model="Model.Filters" />
 
         @if (Model.SearchCount == 0)
         {
@@ -168,7 +130,7 @@
                     @if (Model.HasPreviousPage)
                     {
                         <li class="moj-pagination__item  moj-pagination__item--prev">
-                            <a class="moj-pagination__link" asp-page="/Home/Index" asp-route-currentPage="@Model.PreviousPage" asp-route-TitleFilter="@Model.TitleFilter">Previous<span class="govuk-visually-hidden"> set of pages</span></a>
+                            <a class="moj-pagination__link" asp-page="/Home/Index" asp-route-currentPage="@Model.PreviousPage" asp-route-Title="@Model.Filters.Title">Previous<span class="govuk-visually-hidden"> set of pages</span></a>
                         </li>
                     }
                     @for (var pageIdx = 0; pageIdx < Model.TotalPages; pageIdx++)
@@ -189,7 +151,7 @@
                             }
 
                             <li class="moj-pagination__item @markAsSelected">
-                                <a id="@pageNumber" asp-page="/Home/Index" asp-route-currentPage="@pageNumber" asp-route-TitleFilter="@Model.TitleFilter" class="moj-pagination__link" aria-label="@ariaLabel">@pageNumber</a>
+                                <a id="@pageNumber" asp-page="/Home/Index" asp-route-currentPage="@pageNumber" asp-route-Title="@Model.Filters.Title" class="moj-pagination__link" aria-label="@ariaLabel">@pageNumber</a>
                             </li>
 
                             if (Model.HasNextPage && Model.NextPage == pageNumber && ((Model.NextPage + 1) < Model.TotalPages))
@@ -204,7 +166,7 @@
                     @if (Model.HasNextPage)
                     {
                         <li class="moj-pagination__item  moj-pagination__item--next">
-                            <a class="moj-pagination__link" asp-page="/Home/Index" asp-route-currentPage="@Model.NextPage" asp-route-TitleFilter="@Model.TitleFilter">Next<span class="govuk-visually-hidden"> set of pages</span></a>
+                            <a class="moj-pagination__link" asp-page="/Home/Index" asp-route-currentPage="@Model.NextPage" asp-route-Title="@Model.Filters.Title">Next<span class="govuk-visually-hidden"> set of pages</span></a>
                         </li>
                     }
                 </ul>

--- a/Dfe.PrepareTransfers.Web/Pages/Shared/_ProjectListFilters.cshtml
+++ b/Dfe.PrepareTransfers.Web/Pages/Shared/_ProjectListFilters.cshtml
@@ -1,0 +1,42 @@
+﻿@using Dfe.PrepareTransfers.Web.Utils
+@model Dfe.PrepareTransfers.Web.Models.ProjectList.ProjectListFilters
+
+<details class="govuk-details prepare-project-listing__filters-container" data-module="govuk-details" @(Model.IsFiltered ? "open" : null)>
+    <summary class="govuk-details__summary prepare-project-listing__fitlers-details-summary">
+        <span class="govuk-details__summary-text govuk-button govuk-button--secondary prepare-project-listing__button--main" data-cy="select-projectlist-filter-expand">
+            Filter projects
+        </span>
+    </summary>
+    <div class="govuk-details__text prepare-project-listing__filters-details" data-id="filter-container">
+        <form method="get" class="form">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-one-quarter">
+                    <div class="govuk-form-group">
+                        <h1 class="govuk-label-wrapper">
+                            <label class="govuk-label govuk-label--s" for="filter-project-title">
+                                Project title
+                            </label>
+                        </h1>
+                        <div id="filter-project-title-hint" class="govuk-hint">
+                            For example, The Rutland Learning Trust
+                        </div>
+
+                        <input asp-for="Title" class="govuk-input" type="text" aria-describedby="filter-project-title-hint">
+                    </div>
+                </div>
+            </div>
+
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <div class="govuk-button-group">
+                        <button class="govuk-button govuk-button--secondary prepare-project-listing__button--apply" data-cy="select-projectlist-filter-apply" data-module="govuk-button ">
+                            Apply filters
+                        </button>
+
+                        <a class="govuk-link" href="/home">Clear filters</a>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+</details>

--- a/Dfe.PrepareTransfers.Web/Utils/TypeSpaceExtensions.cs
+++ b/Dfe.PrepareTransfers.Web/Utils/TypeSpaceExtensions.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Html;
+using System;
+using System.Text.RegularExpressions;
+
+namespace Dfe.PrepareTransfers.Web.Utils;
+
+public static class TypespaceExtensions
+{
+   private static readonly Regex NotAlphaNumeric = new("[^[a-z0-9-_]", RegexOptions.Compiled | RegexOptions.CultureInvariant, TimeSpan.FromSeconds(2));
+
+   public static HtmlString Stub(this string input)
+   {
+      return new HtmlString(NotAlphaNumeric.Replace(input.ToLowerInvariant(), "-"));
+   }
+}


### PR DESCRIPTION
## Ticket

[156379](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Manage%20Academy%20Projects/Academies-and-Free-Schools-SIP/Academisation%20Team/Sprint%204-%20Q4?workitem=156379)

## Description

This is a refactor only. It applies to the filtering on the transfers list page.

 - I have move the filter button/panel html into it's own code space
 - I have created a new filter model and moved the title filter into that model

This is now more consistent with conversions and will make handling/maintaining the filter(s) and query parameter(s) much easier when we get to it.
