### PR TITLE
clear filter will reset url and filters

### DIFF
--- a/Dfe.PrepareTransfers.Web/Pages/Shared/_ProjectListFilters.cshtml
+++ b/Dfe.PrepareTransfers.Web/Pages/Shared/_ProjectListFilters.cshtml
@@ -33,7 +33,7 @@
                             Apply filters
                         </button>
 
-                        <a class="govuk-link" href="/home">Clear filters</a>
+                        <a class="govuk-link" href="@Url.RouteUrl(ViewContext.RouteData.Values)?clear">Clear filters</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Pressing "clear filters" on the transfer list did not have any effect.

Ticket: https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Manage%20Academy%20Projects/Academies-and-Free-Schools-SIP/Academisation%20Team/Sprint%204-%20Q4?workitem=156585