### PR TITLE
Disable CDN health probes

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -169,6 +169,7 @@ No resources.
 | <a name="input_dns_txt_records"></a> [dns\_txt\_records](#input\_dns\_txt\_records) | DNS TXT records to add to the DNS Zone | <pre>map(<br>    object({<br>      ttl : optional(number, 300),<br>      records : list(string)<br>    })<br>  )</pre> | n/a | yes |
 | <a name="input_dns_zone_domain_name"></a> [dns\_zone\_domain\_name](#input\_dns\_zone\_domain\_name) | DNS zone domain name. If created, records will automatically be created to point to the CDN. | `string` | n/a | yes |
 | <a name="input_enable_cdn_frontdoor"></a> [enable\_cdn\_frontdoor](#input\_enable\_cdn\_frontdoor) | Set to true to create a CDN | `bool` | n/a | yes |
+| <a name="input_enable_cdn_frontdoor_health_probe"></a> [enable\_cdn\_frontdoor\_health\_probe](#input\_enable\_cdn\_frontdoor\_health\_probe) | Enable CDN Front Door health probe | `bool` | `false` | no |
 | <a name="input_enable_container_registry"></a> [enable\_container\_registry](#input\_enable\_container\_registry) | Set to true to create a container registry | `bool` | n/a | yes |
 | <a name="input_enable_dns_zone"></a> [enable\_dns\_zone](#input\_enable\_dns\_zone) | Conditionally create a DNS zone | `bool` | n/a | yes |
 | <a name="input_enable_event_hub"></a> [enable\_event\_hub](#input\_enable\_event\_hub) | Send Azure Container App logs to an Event Hub sink | `bool` | `false` | no |

--- a/terraform/container-apps-hosting.tf
+++ b/terraform/container-apps-hosting.tf
@@ -38,6 +38,7 @@ module "azure_container_apps_hosting" {
   cdn_frontdoor_origin_fqdn_override        = local.cdn_frontdoor_origin_fqdn_override
   cdn_frontdoor_origin_host_header_override = local.cdn_frontdoor_origin_host_header_override
   cdn_frontdoor_health_probe_protocol       = local.cdn_frontdoor_health_probe_protocol
+  enable_cdn_frontdoor_health_probe         = local.enable_cdn_frontdoor_health_probe
   container_apps_allow_ips_inbound          = local.container_apps_allow_ips_inbound
 
   container_health_probe_path     = local.container_health_probe_path

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -31,6 +31,7 @@ locals {
   cdn_frontdoor_origin_host_header_override    = var.cdn_frontdoor_origin_host_header_override
   cdn_frontdoor_forwarding_protocol            = var.cdn_frontdoor_forwarding_protocol
   cdn_frontdoor_health_probe_protocol          = var.cdn_frontdoor_health_probe_protocol
+  enable_cdn_frontdoor_health_probe            = var.enable_cdn_frontdoor_health_probe
   key_vault_access_ipv4                        = var.key_vault_access_ipv4
   tfvars_filename                              = var.tfvars_filename
   container_health_probe_path                  = var.container_health_probe_path

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -133,6 +133,12 @@ variable "cdn_frontdoor_health_probe_protocol" {
   default     = "Https"
 }
 
+variable "enable_cdn_frontdoor_health_probe" {
+  description = "Enable CDN Front Door health probe"
+  type        = bool
+  default     = false
+}
+
 variable "container_health_probe_path" {
   description = "Specifies the path that is used to determine the liveness of the Container"
   type        = string


### PR DESCRIPTION
Front Door's health probes are designed to detect situations where an origin is unavailable or unhealthy. When a health probe detects a problem with an origin, Front Door can be configured to send traffic to another origin in the origin group.

If you only have a single origin, Front Door always routes traffic to that origin even if its health probe reports an unhealthy status. The status of the health probe doesn't do anything to change Front Door's behavior. In this scenario, health probes don't provide a benefit and you should disable them to reduce the traffic on your origin.