### PR TITLE
Add exclusion paths for build and test

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -3,9 +3,17 @@ name: .NET Build and Test
 on:
   push:
     branches: [ main ]
+    paths:
+    - 'Dfe.PrepareTransfers.*'
+    - '!end-to-end-tests'
+    - '*.csproj'
   pull_request:
     branches: [ main ]
     types: [ opened, synchronize, reopened]
+    paths:
+    - 'Dfe.PrepareTransfers.*'
+    - '!end-to-end-tests'
+    - '*.csproj'
 
 env:
   DOTNET_VERSION: '6.0.403'


### PR DESCRIPTION
Sets paths to restrict when to run build and test.

This is to reduce the amount of times that sonarcloud is ran and to free up github runners