### PR TITLE
Reusable Cypress workflow

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -95,6 +95,7 @@ jobs:
 
   cypress-tests:
     name: Run Cypress Tests
+    needs: [ set-env, deploy-image ]
     if: needs.set-env.outputs.environment == 'staging' || needs.set-env.outputs.environment == 'dev'
     uses: ./.github/workflows/cypress.yml
     with:

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -94,54 +94,7 @@ jobs:
             }
 
   cypress-tests:
-    name: Run Cypress Tests
     if: needs.set-env.outputs.environment == 'staging' || needs.set-env.outputs.environment == 'dev'
-    needs: [ deploy-image, set-env ]
-    runs-on: ubuntu-22.04
-    environment: ${{ needs.set-env.outputs.environment }}
-    defaults:
-      run:
-        working-directory: end-to-end-tests
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Setup node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Npm install
-        run: npm install
-
-      - name: Run cypress (${{ needs.set-env.outputs.environment }})
-        run: npm run cy:run -- --env url='${{ secrets.AZURE_ENDPOINT }}',authorizationHeader='${{ secrets.AUTH_HEADER_CYPRESS }}, academisationApiUrl=${{secrets.CYPRESS_ACADEMISATION_API_URL}}, academisationApiKey=${{ secrets.CYPRESS_ACADEMISATION_API_KEY}}'
-        env:
-          db: ${{ secrets.DB_CONNECTION_STRING }}
-
-      - name: Upload screenshots
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: screenshots-${{ needs.set-env.outputs.environment }}
-          path: end-to-end-tests/cypress/screenshots
-
-      - name: Generate report
-        if: always()
-        run: |
-          mkdir mochareports
-          npm run generate:html:report
-
-      - name: Upload report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: reports-${{ needs.set-env.outputs.environment }}
-          path: end-to-end-tests/mochareports/
-
-      - name: Report results
-        if: always()
-        run: npm run cy:notify -- --custom-text="Environment ${{ needs.set-env.outputs.environment }}, See more information https://github.com/DFE-Digital/prepare-academy-transfers/actions/runs/${{github.run_id}}"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    uses: ./.github/workflows/cypress.yml
+    with:
+      environment: ${{ needs.set-env.outputs.environment }}

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -94,6 +94,7 @@ jobs:
             }
 
   cypress-tests:
+    name: Run Cypress Tests
     if: needs.set-env.outputs.environment == 'staging' || needs.set-env.outputs.environment == 'dev'
     uses: ./.github/workflows/cypress.yml
     with:

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -100,3 +100,10 @@ jobs:
     uses: ./.github/workflows/cypress.yml
     with:
       environment: ${{ needs.set-env.outputs.environment }}
+    secrets:
+      AZURE_ENDPOINT: ${{ secrets.AZURE_ENDPOINT }}
+      CYPRESS_TEST_SECRET: ${{ secrets.CYPRESS_TEST_SECRET }}
+      CYPRESS_ACADEMISATION_API_URL: ${{ secrets.CYPRESS_ACADEMISATION_API_URL }}
+      CYPRESS_ACADEMISATION_API_KEY: ${{ secrets.CYPRESS_ACADEMISATION_API_KEY }}
+      DB_CONNECTION_STRING: ${{ secrets.DB_CONNECTION_STRING }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,4 +1,4 @@
-name: Run Cypress Manually Triggered
+name: Run Cypress tests
 
 on:
   workflow_call:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -6,6 +6,19 @@ on:
       environment:
         required: true
         type: string
+    secrets:
+      AZURE_ENDPOINT:
+        required: true
+      CYPRESS_TEST_SECRET:
+        required: true
+      CYPRESS_ACADEMISATION_API_URL:
+        required: true
+      CYPRESS_ACADEMISATION_API_KEY:
+        required: true
+      DB_CONNECTION_STRING:
+        required: true
+      SLACK_WEBHOOK_URL:
+        required: true
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,7 +1,17 @@
 name: Run Cypress Manually Triggered
 
 on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to run tests against'
+        required: true
+        type: environment
 
 concurrency:
   group: ${{ github.workflow }}
@@ -13,7 +23,7 @@ jobs:
   cypress-tests:
     name: Run Cypress Tests
     runs-on: ubuntu-latest
-    environment: dev
+    environment: ${{ inputs.environment }}
     defaults:
       run:
         working-directory: end-to-end-tests/
@@ -30,7 +40,8 @@ jobs:
       - name: Npm install
         run: npm install
 
-      - name: Run cypress (dev)
+      - name: Run Cypress (${{ inputs.environment }})
+        if: inputs.environment == 'staging' || inputs.environment == 'dev'
         run: npm run cy:run -- --env url='${{ secrets.AZURE_ENDPOINT }}',authorizationHeader='${{ secrets.CYPRESS_TEST_SECRET }}, academisationApiUrl=${{secrets.CYPRESS_ACADEMISATION_API_URL}}, academisationApiKey=${{ secrets.CYPRESS_ACADEMISATION_API_KEY}}'
         env:
           db: ${{ secrets.DB_CONNECTION_STRING }}
@@ -57,6 +68,6 @@ jobs:
 
       - name: Report results
         if: always()
-        run: npm run cy:notify -- --custom-text="Environment dev, See more information https://github.com/DFE-Digital/prepare-academy-transfers/actions/runs/${{github.run_id}}"
+        run: npm run cy:notify -- --custom-text="Environment ${{ inputs.environment }}, See more information https://github.com/DFE-Digital/prepare-academy-transfers/actions/runs/${{github.run_id}}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Pulls out the Cypress tests into their own reusable workflow independent of the deploy workflow.

Cypress workflow can now either be triggered manually for dev/staging, or is called after a successful deployment.